### PR TITLE
Make sogulp work with legacy sites that do not support composer.

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -12,6 +12,7 @@ module.exports = {
   work: workDir,
   vendors: vendorsDir,
   packages: packagesDir,
+  composerLock: 'composer.lock',
   less: [
     'www/styles/*.less',
     'www/styles/*/*.less',


### PR DESCRIPTION
Also fix issues with 'concentrate' and 'clean' tasks.