### PR TITLE
Switch from gulp.watch (gaze) to chokidar.

### DIFF
--- a/lib/lesswatcher.js
+++ b/lib/lesswatcher.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var gutil = require('gulp-util');
+var chokidar = require('chokidar');
+var q = require('q');
+
+var paths = require('./paths');
+var less = require('./less');
+
+module.exports = {
+  watch: function() {
+    var deferred = q.defer();
+
+    var watcher = chokidar.watch(
+      paths.less,
+      {
+        persistent: true,
+        followSymlinks: true
+      }
+    );
+
+    watcher.on('ready', function() {
+
+      watcher.on('all', function() {
+        gutil.log(
+          gutil.colors.gray('..'),
+          gutil.colors.magenta('starting less build')
+        );
+        less.task().on('end', function() {
+          gutil.log(
+            gutil.colors.gray('..'),
+            gutil.colors.magenta('finished less build')
+          );
+        });
+      });
+
+      deferred.resolve();
+    });
+
+    return deferred.promise;
+  }
+};

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -24,7 +24,7 @@ module.exports = {
     'system/**/*.php',
     'newsletter/**/*.php',
     'www/*.php',
-    'vendor/**/*.php'
+    'www/admin/*.php'
   ],
   min: 'www/min',
   compiled: 'www/compiled',

--- a/lib/phpwatcher.js
+++ b/lib/phpwatcher.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var gutil = require('gulp-util');
+var fs = require('fs');
+var chokidar = require('chokidar');
+var path = require('path');
+var q = require('q');
+
+var paths = require('./paths');
+var phplint = require('./phplint');
+var phpclassmap = require('./phpclassmap');
+
+module.exports = {
+  watch: function() {
+    var deferred = q.defer();
+
+    var hasComposer = fs.existsSync(paths.composerLock);
+
+    // Chokidar can't glob symlink directories properly so explicitly list
+    // each directory instead.
+    var watchPaths = paths.php.slice();
+    fs.readdirSync(paths.vendors).forEach(function(dir) {
+      dir = path.join(paths.vendors, dir);
+      var stats = fs.lstatSync(dir);
+      if (stats.isSymbolicLink()) {
+        watchPaths.push(path.join(dir, '**', '*.php'));
+      }
+    });
+
+    var watcher = chokidar.watch(
+      watchPaths,
+      {
+        // Ignore composer autoload files and backup silverorange composer
+        // package directories.
+        ignored: [
+          /^vendor\/autoload.php$/,
+          /^vendor\/composer\/.*\.php$/,
+          /^vendor\/silverorange\/.*\.original\/.*\.php$/
+        ],
+        persistent: true,
+        followSymlinks: true
+      }
+    );
+
+    watcher.on('ready', function() {
+      var watchAllHandler = function() {
+        if (hasComposer) {
+          gutil.log(
+            gutil.colors.gray('..'),
+            gutil.colors.magenta('starting dump-autoload')
+          );
+          phpclassmap.task().then(function() {
+            gutil.log(
+              gutil.colors.gray('..'),
+              gutil.colors.magenta('finished dump-autoload')
+            );
+          });
+        }
+      };
+
+      var watchChangedHandler = function(path) {
+        phplint.stream(path);
+      };
+
+      watcher.on('all', function(path) { watchAllHandler(path); });
+      watcher.on('add', function(path) { watchChangedHandler(path); });
+      watcher.on('change', function(path) { watchChangedHandler(path); });
+
+      deferred.resolve();
+    });
+
+    return deferred.promise;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/silverorange/sogulp/issues"
   },
   "dependencies": {
+    "chokidar": "^1.5.1",
     "gulp": ">=3.5.5",
     "gulp-css-url-rebase": ">=0.2.2",
     "gulp-less": ">=1.2.1",


### PR DESCRIPTION
On Linux this switches from polling to inotify events. This is *much* faster.

Also fix a recursive classmap rebuild issue. Make sure the classmap PHP files are excluded from the watch list.