### PR TITLE
Emit end event on error so watcher tasks know to complete.

### DIFF
--- a/lib/less.js
+++ b/lib/less.js
@@ -26,6 +26,8 @@ module.exports = {
       .pipe(less({ paths: [path.join(__dirname, 'www')] }))
       .on('error', function(e) {
         gutil.log(gutil.colors.red('LESSC ERROR:'), e.message);
+        // Needed so watcher tasks get notified the stream has ended.
+        this.emit('end');
       })
 
       // Rebase relative URIs inside CSS to match new location.


### PR DESCRIPTION
Fixes issue where LESSC error would prevent subsequent rebuilding of LESS files.