### PR TITLE
Support multiple vendor paths

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -2,13 +2,16 @@ const path = require('path');
 
 const cwd = process.cwd();
 const workDir = path.basename(cwd);
-const vendorsDir = path.join(cwd, 'vendor', 'silverorange');
+const vendorDirs = [
+  path.join(cwd, 'vendor', 'silverorange'),
+  path.join(cwd, 'vendor', 'hippo')
+];
 const packagesDir = path.join(cwd, 'www', 'packages');
 
 module.exports = {
   cwd,
   work: workDir,
-  vendors: vendorsDir,
+  vendors: vendorDirs,
   packages: packagesDir,
   composerLock: 'composer.lock',
   less: [

--- a/lib/phpwatcher.js
+++ b/lib/phpwatcher.js
@@ -16,13 +16,17 @@ module.exports = {
       // Chokidar can't glob symlink directories properly so explicitly list
       // each directory instead.
       if (hasComposer) {
-        fs.readdirSync(paths.vendors).forEach((dir) => {
-          const vendorDir = path.join(paths.vendors, dir);
-          const stats = fs.lstatSync(vendorDir);
-          if (stats.isSymbolicLink()) {
-            watchPaths.push(path.join(vendorDir, '**', '*.php'));
+        paths.vendors.forEach(vendorPath => {
+          if (fs.existsSync(vendorPath)) {
+            fs.readdirSync(vendorPath).forEach((dir) => {
+              const vendorDir = path.join(vendorPath, dir);
+              const stats = fs.lstatSync(vendorDir);
+              if (stats.isSymbolicLink()) {
+                watchPaths.push(path.join(vendorDir, '**', '*.php'));
+              }
+            });
           }
-        });
+        })
       }
 
       const watcher = chokidar.watch(
@@ -34,6 +38,7 @@ module.exports = {
             /^vendor\/autoload.php$/,
             /^vendor\/composer\/.*\.php$/,
             /^vendor\/silverorange\/.*\.original\/.*\.php$/,
+            /^vendor\/hippo\/.*\.original\/.*\.php$/,
           ],
           persistent: true,
           followSymlinks: true,

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -14,7 +14,7 @@ function setup(err, progress, complete, symlinks) {
   const packages = symlinks.split(',');
     packages.forEach((packageName) => {
 
-    var packageFound = false;
+    let packageFound = false;
     paths.vendors.forEach(vendorPath => {
       if (fs.existsSync(vendorPath)) {
 

--- a/lib/symlinks.js
+++ b/lib/symlinks.js
@@ -12,45 +12,56 @@ const suffix = '.original';
  */
 function setup(err, progress, complete, symlinks) {
   const packages = symlinks.split(',');
-  if (fs.existsSync(paths.vendors)) {
     packages.forEach((packageName) => {
-      const packageLinkPath = path.join(paths.vendors, packageName);
 
-      if (!fs.existsSync(packageLinkPath)) {
-        gutil.log(
-          gutil.colors.red(`.. ${packageName} package not found`)
-        );
-      } else if (!fs.lstatSync(packageLinkPath).isDirectory()) {
-        gutil.log(
-          gutil.colors.red(`.. ${packageName} not a directory`)
-        );
-      } else {
-        const packageRealPath = path.join(
-          '/so',
-          'packages',
-          packageName,
-          paths.work
-        );
+    var packageFound = false;
+    paths.vendors.forEach(vendorPath => {
+      if (fs.existsSync(vendorPath)) {
 
-        if (fs.existsSync(packageRealPath) &&
-          (
-            !fs.existsSync(packageLinkPath) ||
-            packageRealPath !== fs.realpathSync(packageLinkPath)
-          )
-        ) {
-          fs.renameSync(packageLinkPath, packageLinkPath + suffix);
-          fs.symlinkSync(packageRealPath, packageLinkPath);
-          if (progress) {
-            progress(
-              packageName,
-              packageLinkPath,
-              packageRealPath
+        const packageLinkPath = path.join(vendorPath, packageName);
+        if (fs.existsSync(packageLinkPath)) {
+          packageFound = true;
+          if (!fs.lstatSync(packageLinkPath).isDirectory()) {
+            gutil.log(
+              gutil.colors.red(`.. ${packageName} not a directory`)
             );
+          } else {
+            const packageRealPath = path.join(
+              '/so',
+              'packages',
+              packageName,
+              paths.work
+            );
+
+            if (fs.existsSync(packageRealPath) &&
+              (
+                !fs.existsSync(packageLinkPath) ||
+                packageRealPath !== fs.realpathSync(packageLinkPath)
+              )
+            ) {
+              fs.renameSync(packageLinkPath, packageLinkPath + suffix);
+              fs.symlinkSync(packageRealPath, packageLinkPath);
+              if (progress) {
+                progress(
+                  packageName,
+                  packageLinkPath,
+                  packageRealPath
+                );
+              }
+            }
           }
         }
-      }
+    }
+
     });
-  }
+
+    if (!packageFound) {
+      gutil.log(
+        gutil.colors.red(`.. ${packageName} package not found`)
+      );
+    }
+
+  });
 
   return classmapTask().then(() => {
     if (complete) {
@@ -71,24 +82,27 @@ function setup(err, progress, complete, symlinks) {
  * packages
  */
 function teardown(err, progress, complete) {
-  if (fs.existsSync(paths.vendors)) {
-    fs.readdirSync(paths.vendors).forEach((packageName) => {
-      const packageLinkPath = path.join(paths.vendors, packageName);
-      const packageOriginalPath = packageLinkPath + suffix;
-      if (fs.existsSync(packageLinkPath) &&
-        fs.existsSync(packageOriginalPath) &&
-        fs.lstatSync(packageLinkPath).isSymbolicLink() &&
-        fs.lstatSync(packageOriginalPath).isDirectory()
-      ) {
-        fs.unlinkSync(packageLinkPath);
-        fs.renameSync(packageOriginalPath, packageLinkPath);
 
-        if (progress) {
-          progress(packageName, packageLinkPath);
+  paths.vendors.forEach(vendorPath => {
+    if (fs.existsSync(vendorPath)) {
+      fs.readdirSync(vendorPath).forEach((packageName) => {
+        const packageLinkPath = path.join(vendorPath, packageName);
+        const packageOriginalPath = packageLinkPath + suffix;
+        if (fs.existsSync(packageLinkPath) &&
+          fs.existsSync(packageOriginalPath) &&
+          fs.lstatSync(packageLinkPath).isSymbolicLink() &&
+          fs.lstatSync(packageOriginalPath).isDirectory()
+        ) {
+          fs.unlinkSync(packageLinkPath);
+          fs.renameSync(packageOriginalPath, packageLinkPath);
+
+          if (progress) {
+            progress(packageName, packageLinkPath);
+          }
         }
-      }
-    });
-  }
+      });
+    }
+  });
 
   return classmapTask().then(() => {
     if (complete) {
@@ -108,7 +122,7 @@ module.exports = {
   task: {
     setup: function setupTask(symlinks) {
       gutil.log(
-        gutil.colors.blue('Updating symlinks in vendor/silverorange:')
+        gutil.colors.blue('Updating symlinks in vendor directories:')
       );
       return setup(
         null,
@@ -119,7 +133,7 @@ module.exports = {
     },
     teardown: function teardownTask() {
       gutil.log(
-        gutil.colors.blue('Restoring symlinks in vendor/silverorange:')
+        gutil.colors.blue('Restoring symlinks in vendor directories:')
       );
       return teardown(
         null,


### PR DESCRIPTION
I found it easiest to test this on `ercast` since it had packages in each:
- Update package.json to point to this version (`"sogulp": "m-mitchell/sogulp#multiple-vendor-paths"`)
- Run `yarn install`
- Run `gulp --symlinks=kos,academy,notapackage` to test the symlinks portion
- Add an empty PHP file to your kos/academy work dirs to test that it triggers the php watcher

I also tested with similar steps on coursehost (using the `site` package) to make sure that it would still work without a `hippo` vendor directory. 